### PR TITLE
Build System: add lib64 to PKG_CONFIG_PATH

### DIFF
--- a/deps/classes/native
+++ b/deps/classes/native
@@ -20,7 +20,7 @@ build_native() {
     export CXXFLAGS="-g -fPIC -I${install_dir}/include"
     export LDFLAGS="-L${install_dir}/lib"
 
-    export PKG_CONFIG_PATH=$install_dir/lib/pkgconfig
+    export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig:$install_dir/lib64/pkgconfig"
 
     cd $work_dir
     build


### PR DESCRIPTION
Fixes build on 64bit Linux, see Issue: https://github.com/Airbitz/airbitz-core/issues/1
