### PR TITLE
Prevent hang when calculating fees

### DIFF
--- a/abcd/General.cpp
+++ b/abcd/General.cpp
@@ -138,7 +138,7 @@ Status
 general21FeesUpdate()
 {
     HttpReply reply;
-    const auto url = "https://bitcoinfees.21.co/api/v1/fees/list";
+    const auto url = "https://bitcoinfees.earn.com/api/v1/fees/list";
     const auto path = gContext->paths.twentyOneFeeCachePath();
 
     ABC_CHECK(HttpRequest()
@@ -382,6 +382,8 @@ generalBitcoinFeeInfo()
     standardFeeHigh = highFee;
     for (size_t i = size - 1; i >= 0; i--)
     {
+        if (size == 0) break;
+
         TwentyOneFeeJson twentyOneFeeJson(arrayJson[i]);
 
         // If this is a zero fee estimate, then skip


### PR DESCRIPTION
I remember doing this in a big hurry, around the time 21.com renamed to earn.com, but we apparently never pushed it into the build, since you got them to keep their API running instead. Maybe we should still do this.

* Change 21.co to earn.com for fees API
* Add check for 0 size fee info array