### PR TITLE
Update build recipes to work on modern Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ $(shell sed -i '/#define DEFAULT_HIDDENBITSKEY ".*"/c\#define DEFAULT_HIDDENBITS
 endif
 
 # Compiler options:
+PROTOC ?= protoc
 CFLAGS   += -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c99
 CXXFLAGS += -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c++11
 deps = jansson libbitcoin libcurl libgit2 libqrencode libsecp256k1 libssl libzmq protobuf-lite zlib
@@ -136,11 +137,11 @@ tar:
 # Automatic dependency rules:
 $(WORK_DIR)/%.o: %.c | $(generated_headers)
 	@mkdir -p $(dir $@)
-	$(RUN) $(CC) -c -MD $(CFLAGS) -o $@ $<
+	$(RUN) $(CC) -c -MD $(CPPFLAGS) $(CFLAGS) -o $@ $<
 
 $(WORK_DIR)/%.o: %.cpp | $(generated_headers)
 	@mkdir -p $(dir $@)
-	$(RUN) $(CXX) -c -MD $(CXXFLAGS) -o $@ $<
+	$(RUN) $(CXX) -c -MD $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
 
 include $(wildcard $(WORK_DIR)/*/*.d $(WORK_DIR)/*/*/*.d $(WORK_DIR)/*/*/*/*.d)
 %.h: ;
@@ -149,7 +150,7 @@ include $(wildcard $(WORK_DIR)/*/*.d $(WORK_DIR)/*/*/*.d $(WORK_DIR)/*/*/*/*.d)
 # Protobuf files:
 codegen/paymentrequest.pb.h codegen/paymentrequest.pb.cc: abcd/bitcoin/spend/paymentrequest.proto
 	@mkdir -p $(dir $@)
-	$(RUN) protoc --cpp_out=$(dir $@) --proto_path=$(dir $<) $<
+	$(RUN) $(PROTOC) --cpp_out=$(dir $@) --proto_path=$(dir $<) $<
 
 codegen/paymentrequest.pb.cpp: codegen/paymentrequest.pb.cc
 	@cp $^ $@

--- a/deps/classes/native
+++ b/deps/classes/native
@@ -16,8 +16,9 @@ build_native() {
     export CC=clang
     export CXX="clang++"
 
-    export CFLAGS="-g -fPIC -I${install_dir}/include"
-    export CXXFLAGS="-g -fPIC -I${install_dir}/include"
+    export CFLAGS="-g -fPIC -Wno-implicit-int"
+    export CPPFLAGS="-I${install_dir}/include"
+    export CXXFLAGS="-g -fPIC"
     export LDFLAGS="-L${install_dir}/lib"
 
     export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig:$install_dir/lib64/pkgconfig"

--- a/deps/recipes/abc/abc.recipe
+++ b/deps/recipes/abc/abc.recipe
@@ -13,6 +13,10 @@ build() {
     export CFLAGS="$CFLAGS -O2"
     export CXXFLAGS="$CXXFLAGS -O2"
 
+    if [ $target = native ]; then
+        export PROTOC=$install_dir/bin/protoc
+    fi
+
     # Build:
     make $output V=1
 

--- a/deps/recipes/curl/curl.recipe
+++ b/deps/recipes/curl/curl.recipe
@@ -1,4 +1,4 @@
-depends="openssl"
+depends="openssl zlib"
 inherit lib
 
 version="7.50.3"
@@ -10,6 +10,7 @@ build() {
     ./configure --enable-static --disable-shared \
         --enable-ipv6 \
         --disable-ldap --without-libssh2 --without-librtmp --without-libidn \
+        --without-nghttp2 --without-libpsl \
         --host=$cross --prefix=$install_dir
     make
     make install

--- a/deps/recipes/libbitcoin/libbitcoin.recipe
+++ b/deps/recipes/libbitcoin/libbitcoin.recipe
@@ -6,6 +6,7 @@ source="https://github.com/libbitcoin/libbitcoin.git#7a1a9d43"
 build() {
     echo Patching...
     patch -p1 < $recipe_dir/config.patch
+    echo "#include <stddef.h>" >> ./include/bitcoin/bitcoin/compat.hpp
 
     echo Building...
     autoreconf -i

--- a/deps/recipes/libsodium/libsodium.recipe
+++ b/deps/recipes/libsodium/libsodium.recipe
@@ -5,6 +5,10 @@ source="https://github.com/jedisct1/libsodium/releases/download/$version/libsodi
 
 build() {
     cd libsodium-$version
+
+    sed -e 's/typedef CRYPTO_ALIGN(64) struct/typedef struct/' -i src/libsodium/include/sodium/crypto_generichash_blake2b.h
+    sed -e 's/ALIGN( 64 )//g' -i src/libsodium/crypto_generichash/blake2/ref/blake2.h
+
     ./autogen.sh
     ./configure --enable-static --disable-shared --host=$cross --prefix=$install_dir
     make

--- a/minilibs/git-sync/readme.md
+++ b/minilibs/git-sync/readme.md
@@ -3,3 +3,27 @@
 This is a tiny library and command-line utility for syncing files using Git.
 The library runs inside the mobile app,
 and the command-line utility runs on the server.
+
+## Building
+
+You will need the following tools to build the library:
+
+```
+brew install cmake git libtool pkgconfig
+```
+
+First, install libgit2 v0.23.4 on your computer:
+
+```sh
+git clone git@github.com:libgit2/libgit2.git
+cd libgit2
+git checkout v0.23.4
+
+# Now follow the libgit2 readme file:
+mkdir build && cd build
+cmake ..
+cmake --build .
+cmake --install .
+```
+
+Now run `make` in this folder to build the `sync` executable. Note that some users prefer to rename the `sync` binary to `ab-sync`.


### PR DESCRIPTION
- Work around -Wno-implicit-int issue breaking autoconf scripts.
- Prevent cURL from trying to use more system libraries
- Work around C++ standard library change affecting libbitcoin
- Work around alignment issue affecting libsodium
- Use our self-compiled version of protoc, instead of the system one.

The first commit is something I found in my working tree from who-knows when.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206868064296421